### PR TITLE
chore(dependencies): bump @typescript-eslint/eslint-plugin (6.7.4 -> 6.7.5)

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@babel/core": "^7.23.0",
     "@babel/eslint-parser": "^7.22.15",
     "@rushstack/eslint-patch": "^1.5.1",
-    "@typescript-eslint/eslint-plugin": "^6.7.4",
+    "@typescript-eslint/eslint-plugin": "^6.7.5",
     "@typescript-eslint/parser": "^6.7.4",
     "babel-preset-react-app": "^10.0.1",
     "confusing-browser-globals": "^1.0.11",


### PR DESCRIPTION

@typescript-eslint/eslint-plugin@6.7.5 | MIT | deps: 11 | versions: 3037
TypeScript plugin for ESLint
https://github.com/typescript-eslint/typescript-eslint#readme

keywords: eslint, eslintplugin, eslint-plugin, typescript

dist
.tarball: https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.7.5.tgz
.shasum: f4024b9f63593d0c2b5bd6e4ca027e6f30934d4f
.integrity: sha512-JhtAwTRhOUcP96D0Y6KYnwig/MRQbOoLGXTON2+LlyB/N35SP9j1boai2zzwXb7ypKELXMx3DVk9UTaEq1vHEw==
.unpackedSize: 2.5 MB

dependencies:
@eslint-community/regexpp: ^4.5.1
@typescript-eslint/scope-manager: 6.7.5
@typescript-eslint/type-utils: 6.7.5
@typescript-eslint/utils: 6.7.5
@typescript-eslint/visitor-keys: 6.7.5
debug: ^4.3.4
graphemer: ^1.4.0
ignore: ^5.2.4
natural-compare: ^1.4.0
semver: ^7.5.4
ts-api-utils: ^1.0.1

maintainers:
- bradzacher <brad.zacher@gmail.com>
- jameshenry <npm@jameshenry.email>

dist-tags:
canary: 6.7.6-alpha.5
latest: 6.7.5
rc-v3: 3.0.0-alpha.27
rc-v4: 4.0.0-alpha.16
rc-v5: 5.0.0-alpha.42
rc-v6: 7.0.0-alpha.0
rc-v: 6.0.0-alpha.58

published 2 days ago by jameshenry <npm@jameshenry.email>