### PR TITLE
chore(deps): bump @typescript-eslint/parser (6.7.4 -> 6.7.5)

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@babel/eslint-parser": "^7.22.15",
     "@rushstack/eslint-patch": "^1.5.1",
     "@typescript-eslint/eslint-plugin": "^6.7.5",
-    "@typescript-eslint/parser": "^6.7.4",
+    "@typescript-eslint/parser": "^6.7.5",
     "babel-preset-react-app": "^10.0.1",
     "confusing-browser-globals": "^1.0.11",
     "eslint-plugin-flowtype": "^8.0.3",


### PR DESCRIPTION

@typescript-eslint/parser@6.7.5 | BSD-2-Clause | deps: 5 | versions: 3116
An ESLint custom parser which leverages TypeScript ESTree
https://github.com/typescript-eslint/typescript-eslint#readme

keywords: ast, ecmascript, javascript, typescript, parser, syntax, eslint

dist
.tarball: https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.7.5.tgz
.shasum: 8d7ca3d1fbd9d5a58cc4d30b2aa797a760137886
.integrity: sha512-bIZVSGx2UME/lmhLcjdVc7ePBwn7CLqKarUBL4me1C5feOd663liTGjMBGVcGr+BhnSLeP4SgwdvNnnkbIdkCw==
.unpackedSize: 17.7 kB

dependencies:
@typescript-eslint/scope-manager: 6.7.5
@typescript-eslint/types: 6.7.5
@typescript-eslint/typescript-estree: 6.7.5
@typescript-eslint/visitor-keys: 6.7.5
debug: ^4.3.4

maintainers:
- bradzacher <brad.zacher@gmail.com>
- jameshenry <npm@jameshenry.email>

dist-tags:
canary: 6.7.6-alpha.5
latest: 6.7.5
rc-v3: 3.0.0-alpha.27
rc-v4: 4.0.0-alpha.16
rc-v5: 5.0.0-alpha.42
rc-v6: 7.0.0-alpha.0
rc-v: 6.0.0-alpha.58

published 2 days ago by jameshenry <npm@jameshenry.email>