### PR TITLE
chore(deps): bump @babel/core (7.23.0 -> 7.23.2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "eslint": "^8.0.0"
   },
   "dependencies": {
-    "@babel/core": "^7.23.0",
+    "@babel/core": "^7.23.2",
     "@babel/eslint-parser": "^7.22.15",
     "@rushstack/eslint-patch": "^1.5.1",
     "@typescript-eslint/eslint-plugin": "^6.7.5",


### PR DESCRIPTION

@babel/core@7.23.2 | MIT | deps: 15 | versions: 168
Babel compiler core.
https://babel.dev/docs/en/next/babel-core

keywords: 6to5, babel, classes, const, es6, harmony, let, modules, transpile, transpiler, var, babel-core, compiler

dist
.tarball: https://registry.npmjs.org/@babel/core/-/core-7.23.2.tgz
.shasum: ed10df0d580fff67c5f3ee70fd22e2e4c90a9f94
.integrity: sha512-n7s51eWdaWZ3vGT2tD4T7J6eJs3QoBXydv7vkUM06Bf1cbVD2Kc2UrkzhiQwobfV7NwOnQXYL7UBJ5VPU+RGoQ==
.unpackedSize: 777.6 kB

dependencies:
@ampproject/remapping: ^2.2.0
@babel/code-frame: ^7.22.13
@babel/generator: ^7.23.0
@babel/helper-compilation-targets: ^7.22.15
@babel/helper-module-transforms: ^7.23.0
@babel/helpers: ^7.23.2
@babel/parser: ^7.23.0
@babel/template: ^7.22.15
@babel/traverse: ^7.23.2
@babel/types: ^7.23.0
convert-source-map: ^2.0.0
debug: ^4.1.0
gensync: ^1.0.0-beta.2
json5: ^2.2.3
semver: ^6.3.1

maintainers:
- hzoo <hi@henryzoo.com>
- existentialism <bng412@gmail.com>
- nicolo-ribaudo <nicolo.ribaudo@gmail.com>
- jlhwung <jlhwung@gmail.com>

dist-tags:
bridge6: 6.0.0-bridge.1
esm: 7.21.4-esm.4
latest: 7.23.2
next: 8.0.0-alpha.4

published 5 hours ago by nicolo-ribaudo <nicolo.ribaudo@gmail.com>